### PR TITLE
feat: adds useGasEstimate hook

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -21,3 +21,5 @@ export * from "@/hooks/useBatchSession"
 export * from "@/hooks/useUserOpWait"
 
 export * from "@/hooks/useTokenFees"
+
+export * from "@/hooks/useGasEstimate"

--- a/src/hooks/useGasEstimate.ts
+++ b/src/hooks/useGasEstimate.ts
@@ -1,0 +1,76 @@
+import { useSmartAccount } from "@/hooks"
+import type { BuildUserOpOptions, Transaction } from "@biconomy/account"
+import {
+  type QueryKey,
+  type UseQueryOptions,
+  useQuery
+} from "@tanstack/react-query"
+import type { UseQueryParameters } from "wagmi/query"
+
+export type UseGasEstimatePayload = {
+  /** The transactions to be batched. */
+  transactions: Transaction[]
+  /** The BuildUserOpOptions options. See https://bcnmy.github.io/biconomy-client-sdk/types/BuildUserOpOptions.html for further detail*/
+  buildUseropDto?: BuildUserOpOptions
+}
+/**
+
+@description This hook retrieves gas estimates for a given set of transactions using the smart account.
+
+@example
+
+```tsx
+import { useGasEstimate } from "@biconomy/useAA";
+import { useSmartAccount } from "@/hooks";
+import { encodeFunctionData, parseAbi } from "wagmi";
+
+export const GasEstimate = () => {
+  const { smartAccountAddress } = useSmartAccount();
+
+  const mintTx: Transaction = {
+    to: "0x1758f42Af7026fBbB559Dc60EcE0De3ef81f665e",
+    data: encodeFunctionData({
+      abi: parseAbi(["function safeMint(address _to)"]),
+      functionName: "safeMint",
+      args: [smartAccountAddress],
+    }),
+  };
+
+  const { data: gasEstimate, error, isLoading } = useGasEstimate({ transactions: [mintTx] });
+
+  if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error.message}</div>;
+
+  return (
+    <div>
+      Gas Estimate: {gasEstimate ? gasEstimate.toString() : "No estimate available"}
+    </div>
+  );
+};
+```
+*/
+export const useGasEstimate = (
+  params: UseGasEstimatePayload,
+  queryParams?: UseQueryParameters
+) => {
+  const { smartAccountClient, queryClient } = useSmartAccount()
+  const { transactions, buildUseropDto } = params
+  return useQuery(
+    {
+      queryKey: ["gasEstimate", transactions, buildUseropDto],
+      queryFn: async () => {
+        if (!smartAccountClient) {
+          throw new Error("No smart account found")
+        }
+
+        return await smartAccountClient.getGasEstimate(
+          transactions,
+          buildUseropDto
+        )
+      },
+      enabled: !!transactions.length,
+      ...queryParams
+    } as UseQueryOptions<bigint, Error, bigint, QueryKey>,
+    queryClient
+  )
+}

--- a/src/stories/GasEstimateHook.stories.tsx
+++ b/src/stories/GasEstimateHook.stories.tsx
@@ -1,0 +1,30 @@
+import { GasEstimate } from "@/stories/components/GasEstimate";
+import type { TransactionsBuildUseropDtoHookProps } from "@/stories/utils/types";
+import { PaymasterMode } from "@biconomy/account";
+
+export default {
+  title: "GasEstimate",
+  component: GasEstimate,
+  argTypes: {
+    paymasterMode: {
+      control: "radio",
+      options: [PaymasterMode.SPONSORED, PaymasterMode.ERC20],
+    },
+    to: {
+      type: "string",
+    },
+    value: {
+      type: "number",
+    },
+  },
+};
+
+export const GasEstimateHook = (args: TransactionsBuildUseropDtoHookProps) => {
+  return <GasEstimate {...args} />;
+};
+
+GasEstimateHook.args = {
+  paymasterMode: PaymasterMode.SPONSORED,
+  to: "0xe6dBb5C8696d2E0f90B875cbb6ef26E3bBa575AC",
+  value: 1,
+};

--- a/src/stories/TokenFeesHook.stories.tsx
+++ b/src/stories/TokenFeesHook.stories.tsx
@@ -1,5 +1,5 @@
 import { TokenFees } from "@/stories/components/TokenFees"
-import type { TokenFeesHookProps } from "@/stories/utils/types"
+import type { TransactionsBuildUseropDtoHookProps } from "@/stories/utils/types"
 import { PaymasterMode } from "@biconomy/account"
 
 export default {
@@ -19,7 +19,7 @@ export default {
   }
 }
 
-export const TokenFeesHook = (args: TokenFeesHookProps) => {
+export const TokenFeesHook = (args: TransactionsBuildUseropDtoHookProps) => {
   return <TokenFees {...args} />
 }
 

--- a/src/stories/components/GasEstimate.tsx
+++ b/src/stories/components/GasEstimate.tsx
@@ -1,0 +1,36 @@
+import { ConnectButton } from "@rainbow-me/rainbowkit";
+import { Providers } from "@/stories/components/Providers";
+import { TransactionsBuildUseropDtoHookProps } from "@/stories/utils/types";
+import { useGasEstimate } from "@/hooks/useGasEstimate";
+
+const GasEstimateComponent = (params: TransactionsBuildUseropDtoHookProps) => {
+  const { paymasterMode, to, value } = params;
+  const { isPending, isError, error, isSuccess } = useGasEstimate({
+    transactions: [
+      {
+        to,
+        value,
+      },
+    ],
+    buildUseropDto: {
+      paymasterServiceData: { mode: paymasterMode },
+    },
+  });
+
+  return (
+    <div>
+      <ConnectButton />
+      <span>{isPending && "In progress.."}</span>
+      {isError && <span>{error?.message}</span>}
+      {isSuccess && <span>Success!</span>}
+    </div>
+  );
+};
+
+export const GasEstimate = (params: TransactionsBuildUseropDtoHookProps) => {
+  return (
+    <Providers>
+      <GasEstimateComponent {...params} />
+    </Providers>
+  );
+};

--- a/src/stories/components/TokenFees.tsx
+++ b/src/stories/components/TokenFees.tsx
@@ -1,11 +1,11 @@
 import { useTokenFees } from "@/hooks"
 import { Providers } from "@/stories/components/Providers"
-import type { TokenFeesHookProps } from "@/stories/utils/types"
+import type { TransactionsBuildUseropDtoHookProps } from "@/stories/utils/types"
 import { ConnectButton } from "@rainbow-me/rainbowkit"
 
-const TokenFeesComponent = (params: TokenFeesHookProps) => {
+const TokenFeesComponent = (params: TransactionsBuildUseropDtoHookProps) => {
   const { paymasterMode, to, value } = params
-  const { isPending, isError, error, isSuccess, data } = useTokenFees({
+  const { isPending, isError, error, isSuccess } = useTokenFees({
     transactions: {
       to,
       value
@@ -25,7 +25,7 @@ const TokenFeesComponent = (params: TokenFeesHookProps) => {
   )
 }
 
-export const TokenFees = (params: TokenFeesHookProps) => {
+export const TokenFees = (params: TransactionsBuildUseropDtoHookProps) => {
   return (
     <Providers>
       <TokenFeesComponent {...params} />

--- a/src/stories/utils/types.ts
+++ b/src/stories/utils/types.ts
@@ -4,8 +4,8 @@ export type HookProps = {
   wait: boolean
 }
 
-export type TokenFeesHookProps = {
+export type TransactionsBuildUseropDtoHookProps = {
   paymasterMode: PaymasterMode
   to: string
   value: number
-}
+};


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new `useGasEstimate` hook for retrieving gas estimates for transactions using the smart account.

### Detailed summary
- Added `useGasEstimate` hook in `src/hooks/useGasEstimate.ts`
- Updated types and components related to gas estimates in various files
- Updated stories to use `useGasEstimate` hook for gas estimates

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->