### PR TITLE
fix: fixes import for paymaster options

### DIFF
--- a/src/stories/components/CreateBatchSession.tsx
+++ b/src/stories/components/CreateBatchSession.tsx
@@ -1,6 +1,6 @@
 import { useCreateBatchSession, useUserOpWait } from "@/hooks"
 import { Providers } from "@/stories/components/Providers"
-import { Sponsored, bigIntReplacer } from "@/utils"
+import { Options, bigIntReplacer } from "@/utils"
 import { type Hex, parseAbi } from "viem"
 import type { HookProps } from "../utils/types"
 
@@ -63,7 +63,7 @@ const CreateBatchSessionComponent = (params: HookProps) => {
 
   const handleCreateBatchSession = () =>
     mutate({
-      options: Sponsored,
+      options: Options.Sponsored,
       policy
     })
 

--- a/src/stories/components/CreateSession.tsx
+++ b/src/stories/components/CreateSession.tsx
@@ -1,6 +1,6 @@
 import { useCreateSession, useSmartAccount } from "@/hooks"
 import { Providers } from "@/stories/components/Providers"
-import { Sponsored, bigIntReplacer } from "@/utils"
+import { Options, bigIntReplacer } from "@/utils"
 import React from "react"
 import { type Hex, parseAbi } from "viem"
 import type { HookProps } from "../utils/types"
@@ -40,7 +40,7 @@ const CreateSessionComponent = ({ wait }: HookProps) => {
 
   const handleCreateSession = () => {
     mutate({
-      options: Sponsored,
+      options: Options.Sponsored,
       policy
     })
   }

--- a/src/stories/components/UseBatchSession.tsx
+++ b/src/stories/components/UseBatchSession.tsx
@@ -1,6 +1,6 @@
 import { useBatchSession } from "@/hooks"
 import { Providers } from "@/stories/components/Providers"
-import { Sponsored } from "@/utils"
+import { Options } from "@/utils"
 import type { Transaction } from "@biconomy/account"
 import React from "react"
 import { encodeFunctionData, parseAbi } from "viem"
@@ -42,7 +42,7 @@ const UseBatchSessionComponent = ({ wait }: HookProps) => {
     const correspondingIndexes = [1, 0] // The order of the txs from the sessionBatch
 
     mutate({
-      options: Sponsored,
+      options: Options.Sponsored,
       transactions: txs,
       correspondingIndexes
     })

--- a/src/stories/components/UseSession.tsx
+++ b/src/stories/components/UseSession.tsx
@@ -1,6 +1,6 @@
 import { useSession, useSmartAccount } from "@/hooks"
 import { Providers } from "@/stories/components/Providers"
-import { Sponsored } from "@/utils"
+import { Options } from "@/utils"
 import React from "react"
 import { encodeFunctionData, parseAbi } from "viem"
 import type { HookProps } from "../utils/types"
@@ -30,7 +30,7 @@ const UseSessionComponent = ({ wait }: HookProps) => {
     }
 
     mutate({
-      options: Sponsored,
+      options: Options.Sponsored,
       transactions
     })
   }

--- a/src/stories/components/Withdraw.tsx
+++ b/src/stories/components/Withdraw.tsx
@@ -1,7 +1,7 @@
 import { useSendWithdrawals } from "@/hooks"
 import { Providers } from "@/stories/components/Providers"
 import type { HookProps } from "@/stories/utils/types"
-import { Sponsored } from "@/utils"
+import { Options } from "@/utils"
 import { ConnectButton } from "@rainbow-me/rainbowkit"
 import React from "react"
 
@@ -12,7 +12,7 @@ const WithdrawComponent = (params: HookProps) => {
   const [txHash, setTxHash] = React.useState("")
 
   const withdrawalRequest = {
-    options: Sponsored
+    options: Options.Sponsored
   }
 
   const handleWithdraw = () => {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates references to `Sponsored` to `Options.Sponsored` in multiple components for clarity and consistency.

### Detailed summary
- Replaced `Sponsored` with `Options.Sponsored` for improved clarity and consistency in multiple components.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->